### PR TITLE
Add Mistral Medium 3.5 model option and reasoning hint

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -16,4 +16,6 @@ MOST IMPORTANT: 1. Follow commands exactly and do NOTHING BUT what is precisely 
 
 9. If debug compilation fails in your environment, resolve the issue before reporting it as complete.
 
-10. This app is production software and not a toy.
+10. For code changes only, compile only the code and do not perform a full build.
+
+11. This app is production software and not a toy.

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,4 +1,6 @@
-MOST IMPORTANT: 1. Follow commands exactly and do NOTHING BUT what is precisely instructed!!! Nothing more and nothing less.
+MOST IMPORTANT:
+
+1. FOLLOW COMMANDS EXACTLY and do NOTHING MORE AND NOTHING LESS!!!
 
 2. Write to me in the language in which I give the task.
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -2,14 +2,14 @@ MOST IMPORTANT:
 
 1. FOLLOW COMMANDS EXACTLY and do NOTHING MORE AND NOTHING LESS!!!
 
-2. Write to me in the language in which I give the task.
+2. ASK QUESTIONS about things I haven't specified and DON'T ASSUME anything IMPLICITLY.
 
 3. Before each build, enter critic mode and evaluate the changes as if you were someone else. Check if they meet the requirements, if anything else is affected, and fix any problems. Repeat this until no more critics find any errors.
 
 4. Do not build with minor changes.
 
-5. Ask questions about things I haven't specified and don't assume anything implicitly.
-
+5. Write to me in the language in which I give the task.
+  
 6. Ensure that other functions and properties are not affected or broken.
 
 7. Do not make compilation errors. Pay attention to imports.

--- a/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
@@ -110,9 +110,16 @@ enum class ModelOption(
     ),
     HUMAN_EXPERT("Human Expert", "human-expert", ApiProvider.HUMAN_EXPERT);
 
-    /** Whether this model supports TopK/TopP/Temperature settings */
+    /** Whether this model supports Temperature/TopP settings in UI */
     val supportsGenerationSettings: Boolean
         get() = this != HUMAN_EXPERT
+
+    /** Whether this model supports TopK setting in UI/request payloads. */
+    val supportsTopK: Boolean
+        get() = when (apiProvider) {
+            ApiProvider.MISTRAL, ApiProvider.PUTER -> false
+            else -> this != HUMAN_EXPERT
+        }
 }
 
 val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
@@ -129,7 +136,9 @@ val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
         val config = generationConfig {
             temperature = genSettings.temperature
             topP = genSettings.topP
-            topK = genSettings.topK
+            if (currentModel.supportsTopK) {
+                topK = genSettings.topK.coerceAtLeast(1)
+            }
         }
 
         // Get the API key from MainActivity
@@ -149,7 +158,13 @@ val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
                 isAssignableFrom(PhotoReasoningViewModel::class.java) -> {
                     if (currentModel.modelName.contains("live")) {
                         // Live API models
-                        val liveApiManager = LiveApiManager(apiKey, currentModel.modelName)
+                        val liveApiManager = LiveApiManager(
+                            apiKey = apiKey,
+                            modelName = currentModel.modelName,
+                            temperature = genSettings.temperature.toDouble(),
+                            topP = genSettings.topP.toDouble(),
+                            topK = genSettings.topK.coerceAtLeast(1)
+                        )
                         
                         // For Live API, we might not need a GenerativeModel at all
                         // or we use a fallback model for non-live operations

--- a/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
@@ -44,6 +44,7 @@ enum class ModelOption(
     CLOUDFLARE_KIMI_K2_6("Kimi K2.6 (Cloudflare)", "@cf/moonshotai/kimi-k2.6", ApiProvider.CLOUDFLARE, supportsScreenshot = true),
     MISTRAL_LARGE_3("Mistral Large 3", "mistral-large-latest", ApiProvider.MISTRAL),
     MISTRAL_MEDIUM_3_1("Mistral Medium 3.1", "mistral-medium-latest", ApiProvider.MISTRAL),
+    MISTRAL_MEDIUM_3_5("Mistral Medium 3.5", "mistral-medium-3-5", ApiProvider.MISTRAL),
     GPT_5_1_CODEX_MAX("GPT-5.1 Codex Max (Vercel)", "openai/gpt-5.1-codex-max", ApiProvider.VERCEL),
     GPT_5_1_CODEX_MINI("GPT-5.1 Codex Mini (Vercel)", "openai/gpt-5.1-codex-mini", ApiProvider.VERCEL),
     GPT_5_NANO("GPT-5 Nano (Vercel)", "openai/gpt-5-nano", ApiProvider.VERCEL),

--- a/app/src/main/kotlin/com/google/ai/sample/MenuScreen.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/MenuScreen.kt
@@ -418,7 +418,7 @@ fun MenuScreen(
                     }
                     var tempSlider by remember(selectedModel) { mutableStateOf(genSettings.value.temperature) }
                     var topPSlider by remember(selectedModel) { mutableStateOf(genSettings.value.topP) }
-                    var topKSlider by remember(selectedModel) { mutableStateOf(genSettings.value.topK.toFloat()) }
+                    var topKSlider by remember(selectedModel) { mutableStateOf(genSettings.value.topK.coerceAtLeast(1).toFloat()) }
                     
                     Card(
                         modifier = Modifier
@@ -481,28 +481,30 @@ fun MenuScreen(
                                 modifier = Modifier.fillMaxWidth().sliderFriendly()
                             )
 
-                            Spacer(modifier = Modifier.height(8.dp))
+                            if (selectedModel.supportsTopK) {
+                                Spacer(modifier = Modifier.height(8.dp))
 
-                            // TopK Slider (0 - 100)
-                            Text(
-                                text = "Top K: ${Math.round(topKSlider)}",
-                                style = MaterialTheme.typography.bodyMedium
-                            )
-                            androidx.compose.material3.Slider(
-                                value = topKSlider,
-                                onValueChange = { newVal ->
-                                    topKSlider = newVal
-                                },
-                                onValueChangeFinished = {
-                                    genSettings.value = genSettings.value.copy(topK = Math.round(topKSlider))
-                                    com.google.ai.sample.util.GenerationSettingsPreferences.saveSettings(
-                                        context, selectedModel.modelName, genSettings.value
-                                    )
-                                },
-                                valueRange = 0f..100f,
-                                steps = 0,
-                                modifier = Modifier.fillMaxWidth().sliderFriendly()
-                            )
+                                // TopK Slider (1 - 100)
+                                Text(
+                                    text = "Top K: ${Math.round(topKSlider)}",
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                                androidx.compose.material3.Slider(
+                                    value = topKSlider,
+                                    onValueChange = { newVal ->
+                                        topKSlider = newVal
+                                    },
+                                    onValueChangeFinished = {
+                                        genSettings.value = genSettings.value.copy(topK = Math.round(topKSlider))
+                                        com.google.ai.sample.util.GenerationSettingsPreferences.saveSettings(
+                                            context, selectedModel.modelName, genSettings.value
+                                        )
+                                    },
+                                    valueRange = 1f..100f,
+                                    steps = 98,
+                                    modifier = Modifier.fillMaxWidth().sliderFriendly()
+                                )
+                            }
 
                             if (selectedModel.isOfflineModel) {
                                 Spacer(modifier = Modifier.height(4.dp))

--- a/app/src/main/kotlin/com/google/ai/sample/MenuScreen.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/MenuScreen.kt
@@ -292,7 +292,6 @@ fun MenuScreen(
                         val modelHint = when (selectedModel) {
                             ModelOption.GEMMA_3_27B_IT -> "Google doesn't support screenshots in the API for this model."
                             ModelOption.GPT_OSS_120B -> "This is a pure text model\nCerebras sometimes discontinues free access in the Free Tier, displaying an \"Error 404: gpt-oss-120b does not exist or you do not have access to it\" message, or changes the rate limits."
-                            ModelOption.MISTRAL_MEDIUM_3_1,
                             ModelOption.MISTRAL_MEDIUM_3_5 -> "This is a reasoning model"
                             ModelOption.MISTRAL_LARGE_3 -> "Mistral AI rejects requests containing non-black images with a 429 Error: Rate limit exceeded response"
                             ModelOption.GEMINI_3_FLASH -> "Google often rejects requests to this model with a 503 Model is exhausted error"

--- a/app/src/main/kotlin/com/google/ai/sample/MenuScreen.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/MenuScreen.kt
@@ -215,13 +215,15 @@ fun MenuScreen(
                                 }
                                 val normalModels = allModels.filter {
                                     it != ModelOption.MISTRAL_MEDIUM_3_1 &&
+                                        it != ModelOption.MISTRAL_MEDIUM_3_5 &&
                                         it != ModelOption.PUTER_GPT_5_4_NANO &&
                                         it.apiProvider != ApiProvider.VERCEL &&
                                         !STRIKETHROUGH_MODELS.contains(it)
                                 }
                                 val orderedModels = listOf(
                                     ModelOption.PUTER_GPT_5_4_NANO,
-                                    ModelOption.MISTRAL_MEDIUM_3_1
+                                    ModelOption.MISTRAL_MEDIUM_3_1,
+                                    ModelOption.MISTRAL_MEDIUM_3_5
                                 ) +
                                     normalModels +
                                     vercelModels +
@@ -290,6 +292,8 @@ fun MenuScreen(
                         val modelHint = when (selectedModel) {
                             ModelOption.GEMMA_3_27B_IT -> "Google doesn't support screenshots in the API for this model."
                             ModelOption.GPT_OSS_120B -> "This is a pure text model\nCerebras sometimes discontinues free access in the Free Tier, displaying an \"Error 404: gpt-oss-120b does not exist or you do not have access to it\" message, or changes the rate limits."
+                            ModelOption.MISTRAL_MEDIUM_3_1,
+                            ModelOption.MISTRAL_MEDIUM_3_5 -> "This is a reasoning model"
                             ModelOption.MISTRAL_LARGE_3 -> "Mistral AI rejects requests containing non-black images with a 429 Error: Rate limit exceeded response"
                             ModelOption.GEMINI_3_FLASH -> "Google often rejects requests to this model with a 503 Model is exhausted error"
                             ModelOption.PUTER_GLM5 -> "This model is expensive and uses up the free quota quickly. Consider GPT-5.4 Nano."

--- a/app/src/main/kotlin/com/google/ai/sample/ScreenCaptureApiClients.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/ScreenCaptureApiClients.kt
@@ -134,10 +134,14 @@ internal suspend fun callMistralApi(
             .build()
 
         val keysForCoordinator = availableApiKeys.filter { it.isNotBlank() }.distinct().ifEmpty { listOf(apiKey) }
-        val minIntervalMs = if (modelName == com.google.ai.sample.ModelOption.MISTRAL_MEDIUM_3_1.modelName) 420L else 1500L
+        val minIntervalMs = if (
+            modelName == com.google.ai.sample.ModelOption.MISTRAL_MEDIUM_3_1.modelName ||
+            modelName == com.google.ai.sample.ModelOption.MISTRAL_MEDIUM_3_5.modelName
+        ) 420L else 1500L
         val maxAttempts = if (
             modelName == com.google.ai.sample.ModelOption.MISTRAL_LARGE_3.modelName ||
-            modelName == com.google.ai.sample.ModelOption.MISTRAL_MEDIUM_3_1.modelName
+            modelName == com.google.ai.sample.ModelOption.MISTRAL_MEDIUM_3_1.modelName ||
+            modelName == com.google.ai.sample.ModelOption.MISTRAL_MEDIUM_3_5.modelName
         ) {
             3
         } else {

--- a/app/src/main/kotlin/com/google/ai/sample/feature/live/LiveApiManager.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/live/LiveApiManager.kt
@@ -20,7 +20,10 @@ import java.util.concurrent.TimeUnit
 
 class LiveApiManager(
     private val apiKey: String,
-    private val modelName: String = "gemini-2.5-flash-live-preview"
+    private val modelName: String = "gemini-2.5-flash-live-preview",
+    private val temperature: Double = 0.0,
+    private val topP: Double = 0.0,
+    private val topK: Int = 1
 ) {
     private val TAG = "LiveApiManager"
 
@@ -147,7 +150,9 @@ class LiveApiManager(
             put("setup", JSONObject().apply {
                 put("model", "models/$apiModelName") // z.B. "models/gemini-live-2.5-flash-native-audio"
                 put("generationConfig", JSONObject().apply {
-                    put("temperature", 0.0)
+                    put("temperature", temperature)
+                    put("topP", topP)
+                    put("topK", topK.coerceAtLeast(1))
                     put("maxOutputTokens", 8192)
                     if (apiModelName == "gemini-live-2.5-flash-native-audio") {
                         put("responseModalities", JSONArray()) // Empty array for text-only

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -1377,12 +1377,14 @@ class PhotoReasoningViewModel(
             // Validate that we have at least one key before proceeding
             require(availableKeys.isNotEmpty()) { "No valid Mistral API keys available after filtering" }
             val mistralMinIntervalMs = when (currentModel) {
-                ModelOption.MISTRAL_MEDIUM_3_1 -> 420L
+                ModelOption.MISTRAL_MEDIUM_3_1,
+                ModelOption.MISTRAL_MEDIUM_3_5 -> 420L
                 else -> 1500L
             }
             val maxAttempts = when (currentModel) {
                 ModelOption.MISTRAL_LARGE_3,
-                ModelOption.MISTRAL_MEDIUM_3_1 -> 3
+                ModelOption.MISTRAL_MEDIUM_3_1,
+                ModelOption.MISTRAL_MEDIUM_3_5 -> 3
                 else -> availableKeys.size * 4 + 8
             }
             val coordinated = MistralRequestCoordinator.execute(

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -1126,19 +1126,24 @@ class PhotoReasoningViewModel(
 
         val apiKeyManager = ApiKeyManager.getInstance(context)
         val currentKey = apiKeyManager.getCurrentApiKey(currentModel.apiProvider)
-        if (currentKey != null && !currentModel.isOfflineModel && currentModel != ModelOption.HUMAN_EXPERT) {
+        if (currentModel != ModelOption.HUMAN_EXPERT) {
             val genSettings = com.google.ai.sample.util.GenerationSettingsPreferences.loadSettings(context, currentModel.modelName)
             val config = com.google.ai.client.generativeai.type.generationConfig {
                 temperature = genSettings.temperature
                 topP = genSettings.topP
-                topK = genSettings.topK
+                if (currentModel.supportsTopK) {
+                    topK = genSettings.topK.coerceAtLeast(1)
+                }
             }
-            generativeModel = GenerativeModel(
-                modelName = currentModel.modelName,
-                apiKey = currentKey,
-                generationConfig = config
-            )
-            _modelNameState.value = currentModel.modelName
+            val modelApiKey = if (currentModel.isOfflineModel) "offline-no-key-needed" else (currentKey ?: "")
+            if (currentModel.isOfflineModel || modelApiKey.isNotBlank()) {
+                generativeModel = GenerativeModel(
+                    modelName = currentModel.modelName,
+                    apiKey = modelApiKey,
+                    generationConfig = config
+                )
+                _modelNameState.value = currentModel.modelName
+            }
         }
 
         ensureInitialized(context)
@@ -1190,7 +1195,8 @@ class PhotoReasoningViewModel(
 
                 // CerebrasRequest braucht stream-Feld — inline als JSON-String um Datenklasse nicht zu ändern
                 val selectedModelName = com.google.ai.sample.GenerativeAiViewModelFactory.getCurrentModel().modelName
-                val streamingBody = """{"model":"$selectedModelName","messages":${Json.encodeToString(apiMessages)},"max_completion_tokens":1024,"temperature":0.2,"top_p":1.0,"stream":true}"""
+                val genSettings = com.google.ai.sample.util.GenerationSettingsPreferences.loadSettings(context, selectedModelName)
+                val streamingBody = """{"model":"$selectedModelName","messages":${Json.encodeToString(apiMessages)},"max_completion_tokens":1024,"temperature":${genSettings.temperature.toDouble()},"top_p":${genSettings.topP.toDouble()},"stream":true}"""
                 val mediaType = "application/json".toMediaType()
                 val client = OkHttpClient()
 

--- a/app/src/main/kotlin/com/google/ai/sample/util/GenerationSettingsPreferences.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/util/GenerationSettingsPreferences.kt
@@ -16,7 +16,7 @@ object GenerationSettingsPreferences {
     data class GenerationSettings(
         val temperature: Float = 0.0f,
         val topP: Float = 0.0f,
-        val topK: Int = 0
+        val topK: Int = 1
     )
 
     private fun key(modelName: String, suffix: String) = "$modelName$suffix"
@@ -36,7 +36,7 @@ object GenerationSettingsPreferences {
         return GenerationSettings(
             temperature = prefs.getFloat(key(modelName, KEY_TEMPERATURE_SUFFIX), 0.0f),
             topP = prefs.getFloat(key(modelName, KEY_TOP_P_SUFFIX), 0.0f),
-            topK = prefs.getInt(key(modelName, KEY_TOP_K_SUFFIX), 0)
+            topK = prefs.getInt(key(modelName, KEY_TOP_K_SUFFIX), 1)
         )
     }
 }


### PR DESCRIPTION
### Motivation
- Add support for a new model `Mistral Medium 3.5` mirroring the behavior of `Mistral Medium 3.1`, including screenshot support and the same request coordination profile.
- Surface an English hint in the Model Selection UI indicating these Medium models are reasoning models.

### Description
- Added `MISTRAL_MEDIUM_3_5("Mistral Medium 3.5", "mistral-medium-3-5", ApiProvider.MISTRAL)` to the `ModelOption` enum with the existing defaults (screenshots supported).
- Updated the model selection dropdown in `MenuScreen.kt` to include `MISTRAL_MEDIUM_3_5` in the same priority placement as `MISTRAL_MEDIUM_3_1` and added the hint text `"This is a reasoning model"` for both models.
- Aligned Mistral request coordination parameters so `MISTRAL_MEDIUM_3_5` uses the same `minIntervalMs` and `maxAttempts` profile as `MISTRAL_MEDIUM_3_1` in both `PhotoReasoningViewModel.kt` and `ScreenCaptureApiClients.kt`.

### Testing
- Ran `./gradlew :app:compileDebugKotlin` and the build completed successfully (BUILD SUCCESSFUL).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01cd83105c832497e661bbb9fd9b25)