### PR TITLE
Standard Top‑K auf 1 setzen und Generation‑Settings konsistent anwenden

### DIFF
--- a/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
@@ -110,9 +110,16 @@ enum class ModelOption(
     ),
     HUMAN_EXPERT("Human Expert", "human-expert", ApiProvider.HUMAN_EXPERT);
 
-    /** Whether this model supports TopK/TopP/Temperature settings */
+    /** Whether this model supports Temperature/TopP settings in UI */
     val supportsGenerationSettings: Boolean
         get() = this != HUMAN_EXPERT
+
+    /** Whether this model supports TopK setting in UI/request payloads. */
+    val supportsTopK: Boolean
+        get() = when (apiProvider) {
+            ApiProvider.MISTRAL, ApiProvider.PUTER -> false
+            else -> this != HUMAN_EXPERT
+        }
 }
 
 val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
@@ -129,7 +136,9 @@ val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
         val config = generationConfig {
             temperature = genSettings.temperature
             topP = genSettings.topP
-            topK = genSettings.topK
+            if (currentModel.supportsTopK) {
+                topK = genSettings.topK.coerceAtLeast(1)
+            }
         }
 
         // Get the API key from MainActivity
@@ -149,7 +158,13 @@ val GenerativeViewModelFactory = object : ViewModelProvider.Factory {
                 isAssignableFrom(PhotoReasoningViewModel::class.java) -> {
                     if (currentModel.modelName.contains("live")) {
                         // Live API models
-                        val liveApiManager = LiveApiManager(apiKey, currentModel.modelName)
+                        val liveApiManager = LiveApiManager(
+                            apiKey = apiKey,
+                            modelName = currentModel.modelName,
+                            temperature = genSettings.temperature.toDouble(),
+                            topP = genSettings.topP.toDouble(),
+                            topK = genSettings.topK.coerceAtLeast(1)
+                        )
                         
                         // For Live API, we might not need a GenerativeModel at all
                         // or we use a fallback model for non-live operations

--- a/app/src/main/kotlin/com/google/ai/sample/MenuScreen.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/MenuScreen.kt
@@ -418,7 +418,7 @@ fun MenuScreen(
                     }
                     var tempSlider by remember(selectedModel) { mutableStateOf(genSettings.value.temperature) }
                     var topPSlider by remember(selectedModel) { mutableStateOf(genSettings.value.topP) }
-                    var topKSlider by remember(selectedModel) { mutableStateOf(genSettings.value.topK.toFloat()) }
+                    var topKSlider by remember(selectedModel) { mutableStateOf(genSettings.value.topK.coerceAtLeast(1).toFloat()) }
                     
                     Card(
                         modifier = Modifier
@@ -481,28 +481,30 @@ fun MenuScreen(
                                 modifier = Modifier.fillMaxWidth().sliderFriendly()
                             )
 
-                            Spacer(modifier = Modifier.height(8.dp))
+                            if (selectedModel.supportsTopK) {
+                                Spacer(modifier = Modifier.height(8.dp))
 
-                            // TopK Slider (0 - 100)
-                            Text(
-                                text = "Top K: ${Math.round(topKSlider)}",
-                                style = MaterialTheme.typography.bodyMedium
-                            )
-                            androidx.compose.material3.Slider(
-                                value = topKSlider,
-                                onValueChange = { newVal ->
-                                    topKSlider = newVal
-                                },
-                                onValueChangeFinished = {
-                                    genSettings.value = genSettings.value.copy(topK = Math.round(topKSlider))
-                                    com.google.ai.sample.util.GenerationSettingsPreferences.saveSettings(
-                                        context, selectedModel.modelName, genSettings.value
-                                    )
-                                },
-                                valueRange = 0f..100f,
-                                steps = 0,
-                                modifier = Modifier.fillMaxWidth().sliderFriendly()
-                            )
+                                // TopK Slider (1 - 100)
+                                Text(
+                                    text = "Top K: ${Math.round(topKSlider)}",
+                                    style = MaterialTheme.typography.bodyMedium
+                                )
+                                androidx.compose.material3.Slider(
+                                    value = topKSlider,
+                                    onValueChange = { newVal ->
+                                        topKSlider = newVal
+                                    },
+                                    onValueChangeFinished = {
+                                        genSettings.value = genSettings.value.copy(topK = Math.round(topKSlider))
+                                        com.google.ai.sample.util.GenerationSettingsPreferences.saveSettings(
+                                            context, selectedModel.modelName, genSettings.value
+                                        )
+                                    },
+                                    valueRange = 1f..100f,
+                                    steps = 98,
+                                    modifier = Modifier.fillMaxWidth().sliderFriendly()
+                                )
+                            }
 
                             if (selectedModel.isOfflineModel) {
                                 Spacer(modifier = Modifier.height(4.dp))

--- a/app/src/main/kotlin/com/google/ai/sample/feature/live/LiveApiManager.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/live/LiveApiManager.kt
@@ -20,7 +20,10 @@ import java.util.concurrent.TimeUnit
 
 class LiveApiManager(
     private val apiKey: String,
-    private val modelName: String = "gemini-2.5-flash-live-preview"
+    private val modelName: String = "gemini-2.5-flash-live-preview",
+    private val temperature: Double = 0.0,
+    private val topP: Double = 0.0,
+    private val topK: Int = 1
 ) {
     private val TAG = "LiveApiManager"
 
@@ -147,7 +150,9 @@ class LiveApiManager(
             put("setup", JSONObject().apply {
                 put("model", "models/$apiModelName") // z.B. "models/gemini-live-2.5-flash-native-audio"
                 put("generationConfig", JSONObject().apply {
-                    put("temperature", 0.0)
+                    put("temperature", temperature)
+                    put("topP", topP)
+                    put("topK", topK.coerceAtLeast(1))
                     put("maxOutputTokens", 8192)
                     if (apiModelName == "gemini-live-2.5-flash-native-audio") {
                         put("responseModalities", JSONArray()) // Empty array for text-only

--- a/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/feature/multimodal/PhotoReasoningViewModel.kt
@@ -1126,19 +1126,24 @@ class PhotoReasoningViewModel(
 
         val apiKeyManager = ApiKeyManager.getInstance(context)
         val currentKey = apiKeyManager.getCurrentApiKey(currentModel.apiProvider)
-        if (currentKey != null && !currentModel.isOfflineModel && currentModel != ModelOption.HUMAN_EXPERT) {
+        if (currentModel != ModelOption.HUMAN_EXPERT) {
             val genSettings = com.google.ai.sample.util.GenerationSettingsPreferences.loadSettings(context, currentModel.modelName)
             val config = com.google.ai.client.generativeai.type.generationConfig {
                 temperature = genSettings.temperature
                 topP = genSettings.topP
-                topK = genSettings.topK
+                if (currentModel.supportsTopK) {
+                    topK = genSettings.topK.coerceAtLeast(1)
+                }
             }
-            generativeModel = GenerativeModel(
-                modelName = currentModel.modelName,
-                apiKey = currentKey,
-                generationConfig = config
-            )
-            _modelNameState.value = currentModel.modelName
+            val modelApiKey = if (currentModel.isOfflineModel) "offline-no-key-needed" else (currentKey ?: "")
+            if (currentModel.isOfflineModel || modelApiKey.isNotBlank()) {
+                generativeModel = GenerativeModel(
+                    modelName = currentModel.modelName,
+                    apiKey = modelApiKey,
+                    generationConfig = config
+                )
+                _modelNameState.value = currentModel.modelName
+            }
         }
 
         ensureInitialized(context)
@@ -1190,7 +1195,8 @@ class PhotoReasoningViewModel(
 
                 // CerebrasRequest braucht stream-Feld — inline als JSON-String um Datenklasse nicht zu ändern
                 val selectedModelName = com.google.ai.sample.GenerativeAiViewModelFactory.getCurrentModel().modelName
-                val streamingBody = """{"model":"$selectedModelName","messages":${Json.encodeToString(apiMessages)},"max_completion_tokens":1024,"temperature":0.2,"top_p":1.0,"stream":true}"""
+                val genSettings = com.google.ai.sample.util.GenerationSettingsPreferences.loadSettings(context, selectedModelName)
+                val streamingBody = """{"model":"$selectedModelName","messages":${Json.encodeToString(apiMessages)},"max_completion_tokens":1024,"temperature":${genSettings.temperature.toDouble()},"top_p":${genSettings.topP.toDouble()},"stream":true}"""
                 val mediaType = "application/json".toMediaType()
                 val client = OkHttpClient()
 

--- a/app/src/main/kotlin/com/google/ai/sample/util/GenerationSettingsPreferences.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/util/GenerationSettingsPreferences.kt
@@ -16,7 +16,7 @@ object GenerationSettingsPreferences {
     data class GenerationSettings(
         val temperature: Float = 0.0f,
         val topP: Float = 0.0f,
-        val topK: Int = 0
+        val topK: Int = 1
     )
 
     private fun key(modelName: String, suffix: String) = "$modelName$suffix"
@@ -36,7 +36,7 @@ object GenerationSettingsPreferences {
         return GenerationSettings(
             temperature = prefs.getFloat(key(modelName, KEY_TEMPERATURE_SUFFIX), 0.0f),
             topP = prefs.getFloat(key(modelName, KEY_TOP_P_SUFFIX), 0.0f),
-            topK = prefs.getInt(key(modelName, KEY_TOP_K_SUFFIX), 0)
+            topK = prefs.getInt(key(modelName, KEY_TOP_K_SUFFIX), 1)
         )
     }
 }


### PR DESCRIPTION
### Motivation

- Verhindern, dass `topK` leer/0 wird und verhindern, dass nicht unterstützte Modelle Top‑K erhalten (Puter, Mistral). 
- Einheitliche Anwendung der per‑Modell Generation‑Einstellungen (Temperature/TopP/TopK) in allen Pfaden inklusive Live, Cerebras und Offline‑Modellen.

### Description

- Setze globalen Default für `TopK` auf `1` in `GenerationSettingsPreferences` und beim Laden/Initialisieren (`topK` Default/Prüfung). 
- Füge `supportsTopK` zu `ModelOption` hinzu und deaktiviere es für `ApiProvider.MISTRAL` und `ApiProvider.PUTER`, so dass Top‑K weder UI noch Request‑Payloads erreicht. 
- UI: Blende den Top‑K Slider nur ein, wenn `supportsTopK == true`, setze Slider‑Range auf `1..100` und clamp Initialwert mit `coerceAtLeast(1)`. (`MenuScreen.kt`) 
- Runtime/Request: Wende `generationConfig` nur mit `topK` an, wenn `supportsTopK` wahr ist, und clampe `topK` auf mindestens `1` an allen Stellen (`GenerativeAiViewModelFactory.kt`, `PhotoReasoningViewModel.kt`). 
- Live API: Übergib gespeicherte `temperature`, `topP`, `topK` an `LiveApiManager` und benutze diese Werte in der WebSocket `generationConfig` statt Hardcodes (`LiveApiManager.kt`). 
- Cerebras: Ersetze hardcodierte `temperature`/`top_p` durch die geladenen `GenerationSettings` beim Build der Request‑Payload (`PhotoReasoningViewModel.kt`).

### Testing

- Kompilation (Kotlin) ausgeführt: `./gradlew :app:compileDebugKotlin` und erfolgreich gelaufen (Build successful, nur warnings). 
- Änderungen committed (Commit-Message: `Apply generation settings consistently and default Top K to 1`).

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a01e9407e748324bd32aa0549918be2)