### PR TITLE
Termux-Abschlussmeldung aus Ausgaben entfernen

### DIFF
--- a/app/src/main/kotlin/com/google/ai/sample/ScreenOperatorAccessibilityService.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/ScreenOperatorAccessibilityService.kt
@@ -650,18 +650,22 @@ class ScreenOperatorAccessibilityService : AccessibilityService() {
                 ?: intent.getBundleExtra("result")
 
             val extras = intent.extras
-            val stdout = sequenceOf(
-                resultBundle?.getString("com.termux.app.extra.TERMUX_SERVICE.EXTRA_PLUGIN_RESULT_BUNDLE_STDOUT"),
-                resultBundle?.getString("stdout"),
-                extras?.getString("com.termux.app.extra.TERMUX_SERVICE.EXTRA_PLUGIN_RESULT_BUNDLE_STDOUT"),
-                extras?.getString("stdout")
-            ).firstOrNull { !it.isNullOrBlank() }.orEmpty()
-            val stderr = sequenceOf(
-                resultBundle?.getString("com.termux.app.extra.TERMUX_SERVICE.EXTRA_PLUGIN_RESULT_BUNDLE_STDERR"),
-                resultBundle?.getString("stderr"),
-                extras?.getString("com.termux.app.extra.TERMUX_SERVICE.EXTRA_PLUGIN_RESULT_BUNDLE_STDERR"),
-                extras?.getString("stderr")
-            ).firstOrNull { !it.isNullOrBlank() }.orEmpty()
+            val stdout = TermuxOutputPreferences.removeProcessCompletedPrompt(
+                sequenceOf(
+                    resultBundle?.getString("com.termux.app.extra.TERMUX_SERVICE.EXTRA_PLUGIN_RESULT_BUNDLE_STDOUT"),
+                    resultBundle?.getString("stdout"),
+                    extras?.getString("com.termux.app.extra.TERMUX_SERVICE.EXTRA_PLUGIN_RESULT_BUNDLE_STDOUT"),
+                    extras?.getString("stdout")
+                ).firstOrNull { !it.isNullOrBlank() }.orEmpty()
+            )
+            val stderr = TermuxOutputPreferences.removeProcessCompletedPrompt(
+                sequenceOf(
+                    resultBundle?.getString("com.termux.app.extra.TERMUX_SERVICE.EXTRA_PLUGIN_RESULT_BUNDLE_STDERR"),
+                    resultBundle?.getString("stderr"),
+                    extras?.getString("com.termux.app.extra.TERMUX_SERVICE.EXTRA_PLUGIN_RESULT_BUNDLE_STDERR"),
+                    extras?.getString("stderr")
+                ).firstOrNull { !it.isNullOrBlank() }.orEmpty()
+            )
             val exitCode = when {
                 resultBundle?.containsKey("com.termux.app.extra.TERMUX_SERVICE.EXTRA_PLUGIN_RESULT_BUNDLE_EXIT_CODE") == true -> {
                     resultBundle.getInt("com.termux.app.extra.TERMUX_SERVICE.EXTRA_PLUGIN_RESULT_BUNDLE_EXIT_CODE", Int.MIN_VALUE)

--- a/app/src/main/kotlin/com/google/ai/sample/util/TermuxOutputPreferences.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/util/TermuxOutputPreferences.kt
@@ -5,12 +5,14 @@ import android.content.Context
 object TermuxOutputPreferences {
     private const val PREF_NAME = "termux_output_prefs"
     private const val KEY_PENDING_OUTPUT = "pending_output"
+    private const val PROCESS_COMPLETED_PROMPT = "[Process completed - press Enter]"
 
     fun appendOutput(context: Context, output: String) {
-        if (output.isBlank()) return
+        val sanitizedOutput = removeProcessCompletedPrompt(output).trim()
+        if (sanitizedOutput.isBlank()) return
         val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
         val existing = prefs.getString(KEY_PENDING_OUTPUT, "").orEmpty()
-        val merged = if (existing.isBlank()) output else "$existing\n\n$output"
+        val merged = if (existing.isBlank()) sanitizedOutput else "$existing\n\n$sanitizedOutput"
         val committed = prefs.edit().putString(KEY_PENDING_OUTPUT, merged).commit()
         if (!committed) {
             throw IllegalStateException("Failed to persist pending Termux output")
@@ -19,12 +21,21 @@ object TermuxOutputPreferences {
 
     fun consumeOutput(context: Context): String? {
         val prefs = context.getSharedPreferences(PREF_NAME, Context.MODE_PRIVATE)
-        val value = prefs.getString(KEY_PENDING_OUTPUT, "").orEmpty().trim()
+        val value = removeProcessCompletedPrompt(prefs.getString(KEY_PENDING_OUTPUT, "").orEmpty()).trim()
         if (value.isBlank()) return null
         val committed = prefs.edit().remove(KEY_PENDING_OUTPUT).commit()
         if (!committed) {
             throw IllegalStateException("Failed to clear consumed Termux output")
         }
         return value
+    }
+
+    fun removeProcessCompletedPrompt(output: String): String {
+        val lines = output.lineSequence().toList()
+        val promptIndex = lines.indexOfLast { it.isNotBlank() }
+        if (promptIndex < 0 || lines[promptIndex].trim() != PROCESS_COMPLETED_PROMPT) {
+            return output
+        }
+        return lines.take(promptIndex).joinToString("\n")
     }
 }


### PR DESCRIPTION
### Motivation
- Termux hängt nach jeder Ausführung standardmäßig die Zeile `[Process completed - press Enter]` an, die in Chatbubbles und an die KI weitergereichten Ausgaben störend ist. 
- Ziel ist es, diese Abschlusszeile automatisch zu entfernen, ohne reguläre Ausgaben zu verändern, damit Benutzer- und AI-Handoffs sauberer sind.

### Description
- Fügt in `TermuxOutputPreferences` die Konstante `PROCESS_COMPLETED_PROMPT` und die Hilfsfunktion `removeProcessCompletedPrompt(output: String): String` hinzu, die nur die letzte nicht-leere Zeile entfernt, falls sie exakt der Termux-Abschlussmeldung entspricht. 
- Wendet die Bereinigung in `TermuxOutputPreferences.appendOutput` an, sodass eingehende Termux-Streams vor dem Persistieren gesäubert werden. 
- Wendet die Bereinigung in `TermuxOutputPreferences.consumeOutput` an, sodass beim Abruf gespeicherter Pending-Ausgaben die Abschlusszeile entfernt wird. 
- Säubert die in `ScreenOperatorAccessibilityService.TermuxResultReceiver` aus dem Callback ermittelten `stdout` und `stderr` mit `removeProcessCompletedPrompt` bevor sie geloggt, an die UI weitergegeben oder in die Pending-Ausgabe übernommen werden. 

### Testing
- Führe den vorgegebenen Debug-Kompilierungstest mit `./gradlew :app:compileDebugKotlin` aus, welcher erfolgreich abgeschlossen wurde.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a1ee34f7da88324ac7e986b2171a1b9)