### PR TITLE
Rename PUTER_GLM5 -> PUTER_MIMO_V2_5, preserve legacy preference, and adjust model UI hints/strikeouts

### DIFF
--- a/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/GenerativeAiViewModelFactory.kt
@@ -38,7 +38,7 @@ enum class ModelOption(
     val requiresVisionBackend: Boolean = false
 ) {
     PUTER_GPT_5_4_NANO("GPT-5.4 Nano (Puter)", "openai/gpt-5.4-nano", ApiProvider.PUTER, supportsScreenshot = true),
-    PUTER_GLM5("GLM-5V Turbo (Puter)", "openrouter:z-ai/glm-5v-turbo", ApiProvider.PUTER, supportsScreenshot = true),
+    PUTER_MIMO_V2_5("Mimo-V2.5 (Puter)", "xiaomi/mimo-v2.5", ApiProvider.PUTER, supportsScreenshot = true),
     PUTER_QWEN3_5_FLASH("Qwen3.5-Flash (Puter)", "qwen/qwen3.5-flash-02-23", ApiProvider.PUTER, supportsScreenshot = true),
     GROQ_LLAMA_4_SCOUT_17B("Llama 4 Scout 109B (Groq)", "meta-llama/llama-4-scout-17b-16e-instruct", ApiProvider.GROQ, supportsScreenshot = true),
     CLOUDFLARE_KIMI_K2_6("Kimi K2.6 (Cloudflare)", "@cf/moonshotai/kimi-k2.6", ApiProvider.CLOUDFLARE, supportsScreenshot = true),
@@ -255,7 +255,10 @@ object GenerativeAiViewModelFactory {
         currentModel = try {
             ModelOption.valueOf(modelNameStr ?: ModelOption.MISTRAL_LARGE_3.name)
         } catch (e: IllegalArgumentException) {
-            ModelOption.MISTRAL_LARGE_3
+            when (modelNameStr) {
+                "PUTER_GLM5" -> ModelOption.PUTER_MIMO_V2_5
+                else -> ModelOption.MISTRAL_LARGE_3
+            }
         }
     }
 }

--- a/app/src/main/kotlin/com/google/ai/sample/MenuScreen.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/MenuScreen.kt
@@ -100,10 +100,10 @@ data class MenuItem(
 
 private val STRIKETHROUGH_MODELS = listOf(
     ModelOption.GEMMA_3_27B_IT,
-    ModelOption.MISTRAL_LARGE_3,
     ModelOption.GEMINI_FLASH_LIVE_PREVIEW,
     ModelOption.GEMINI_FLASH_LITE_PREVIEW,
-    ModelOption.QWEN3_5_4B_OFFLINE
+    ModelOption.QWEN3_5_4B_OFFLINE,
+    ModelOption.CLOUDFLARE_KIMI_K2_6
 )
 
 @Composable
@@ -293,9 +293,8 @@ fun MenuScreen(
                             ModelOption.GEMMA_3_27B_IT -> "Google doesn't support screenshots in the API for this model."
                             ModelOption.GPT_OSS_120B -> "This is a pure text model\nCerebras sometimes discontinues free access in the Free Tier, displaying an \"Error 404: gpt-oss-120b does not exist or you do not have access to it\" message, or changes the rate limits."
                             ModelOption.MISTRAL_MEDIUM_3_5 -> "This is a reasoning model"
-                            ModelOption.MISTRAL_LARGE_3 -> "Mistral AI rejects requests containing non-black images with a 429 Error: Rate limit exceeded response"
                             ModelOption.GEMINI_3_FLASH -> "Google often rejects requests to this model with a 503 Model is exhausted error"
-                            ModelOption.PUTER_GLM5 -> "This model is expensive and uses up the free quota quickly. Consider GPT-5.4 Nano."
+                            ModelOption.PUTER_MIMO_V2_5 -> "$0.14/M input | $0.28/M output"
                             ModelOption.PUTER_QWEN3_5_FLASH -> "$0.07/M input | $0.26/M output"
                             ModelOption.GROQ_LLAMA_4_SCOUT_17B -> "30 requests per Min"
                             ModelOption.CLOUDFLARE_KIMI_K2_6 -> "Approx. 15 responses per day are free"


### PR DESCRIPTION
### Motivation
- Rename and update a Puter provider model entry to reflect the correct model identifier and display name and surface updated pricing/hint text in the UI.
- Preserve backward compatibility for stored user preferences that referenced the old enum name.
- Adjust which models are shown as strikethrough in the menu to reflect availability changes.

### Description
- Replaced the `PUTER_GLM5` enum entry with `PUTER_MIMO_V2_5` in `ModelOption` and updated its display name and model identifier to `Mimo-V2.5 (Puter)` / `xiaomi/mimo-v2.5`.
- Added a compatibility mapping in `loadModelPreference` to remap stored preference string `"PUTER_GLM5"` to `ModelOption.PUTER_MIMO_V2_5` to avoid breaking existing user selections.
- Updated `STRIKETHROUGH_MODELS` in `MenuScreen.kt` to remove `MISTRAL_LARGE_3` and add `CLOUDFLARE_KIMI_K2_6`.
- Updated model hint text to remove the old `PUTER_GLM5` hint and add a pricing hint for `PUTER_MIMO_V2_5`, and removed the `MISTRAL_LARGE_3` hint from the list.

### Testing
- Ran `./gradlew build` which completed successfully.
- Ran unit tests with `./gradlew test` and they passed.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a25a51ded948324b822da68f028043e)