### PR TITLE
Fix: prevent WebView reset on dark/light mode switch

### DIFF
--- a/app/src/main/AndroidManifest.xml
+++ b/app/src/main/AndroidManifest.xml
@@ -45,7 +45,8 @@
             android:label="@string/app_name"
             android:theme="@style/Theme.Emptything"
             android:launchMode="singleTop"
-            android:windowSoftInputMode="adjustResize">
+            android:windowSoftInputMode="adjustResize"
+            android:configChanges="uiMode|orientation|screenSize|screenLayout|keyboardHidden">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />


### PR DESCRIPTION
Added android:configChanges=uiMode (plus orientation/screenSize/ screenLayout/keyboardHidden) to MainActivity so the Activity is not recreated when the system switches between dark and light theme. Previously the activity restarted on theme change, causing onCreate to refetch and reload the remote HTML into the WebView, which reset navigation back to the main page.