### PR TITLE
Fix Freedom subscription handling and Firebase fallback key loading

### DIFF
--- a/app/src/main/kotlin/com/google/ai/sample/MainActivity.kt
+++ b/app/src/main/kotlin/com/google/ai/sample/MainActivity.kt
@@ -1253,7 +1253,40 @@ class MainActivity : ComponentActivity() {
         Log.i(TAG, "handlePurchase called for purchase: OrderId: ${purchase.orderId}, Products: ${purchase.products}, State: ${purchase.purchaseState}, Token: ${purchase.purchaseToken}, Ack: ${purchase.isAcknowledged}")
         if (purchase.purchaseState == Purchase.PurchaseState.PURCHASED) {
             Log.d(TAG, "handlePurchase: Purchase state is PURCHASED.")
-            if (MainActivityBillingStateEvaluator.containsSubscriptionProduct(purchase, subscriptionProductId)) {
+            if (MainActivityBillingStateEvaluator.containsSubscriptionProduct(purchase, freedomProductId)) {
+                Log.d(TAG, "handlePurchase: Purchase contains Freedom product ID: $freedomProductId")
+                if (!purchase.isAcknowledged) {
+                    Log.i(TAG, "handlePurchase: Purchase not acknowledged. Acknowledging now.")
+                    val acknowledgePurchaseParams = AcknowledgePurchaseParams.newBuilder()
+                        .setPurchaseToken(purchase.purchaseToken)
+                        .build()
+                    billingClient.acknowledgePurchase(acknowledgePurchaseParams) { ackBillingResult ->
+                        Log.i(TAG, "handlePurchase (acknowledgePurchase): Result code: ${ackBillingResult.responseCode}, Message: ${ackBillingResult.debugMessage}")
+                        if (ackBillingResult.responseCode == BillingClient.BillingResponseCode.OK) {
+                            Log.i(TAG, "Freedom subscription purchase acknowledged successfully.")
+                            updateStatusMessage("Thank you for your Freedom subscription!")
+                            TrialManager.markAsFreedomPurchased(this)
+                            TrialManager.markAsPurchased(this)
+                            updateTrialState(TrialManager.getTrialState(this, null))
+                            evaluateWebViewJsWithRetry("window.onFreedomPurchaseStateChanged && window.onFreedomPurchaseStateChanged(true)")
+                            Log.d(TAG, "handlePurchase Freedom: Stopping TrialTimerService.")
+                            val stopIntent = Intent(this, TrialTimerService::class.java)
+                            stopIntent.action = TrialTimerService.ACTION_STOP_TIMER
+                            startService(stopIntent)
+                        } else {
+                            Log.e(TAG, "Failed to acknowledge purchase: ${ackBillingResult.debugMessage}")
+                            updateStatusMessage("Error confirming purchase: ${ackBillingResult.debugMessage}", true)
+                        }
+                    }
+                } else {
+                    Log.i(TAG, "handlePurchase: Freedom subscription already acknowledged.")
+                    updateStatusMessage("Freedom subscription already active.")
+                    TrialManager.markAsFreedomPurchased(this)
+                    TrialManager.markAsPurchased(this)
+                    updateTrialState(TrialManager.getTrialState(this, null))
+                    evaluateWebViewJsWithRetry("window.onFreedomPurchaseStateChanged && window.onFreedomPurchaseStateChanged(true)")
+                }
+            } else if (MainActivityBillingStateEvaluator.containsSubscriptionProduct(purchase, subscriptionProductId)) {
                 Log.d(TAG, "handlePurchase: Purchase contains target product ID: $subscriptionProductId")
                 if (!purchase.isAcknowledged) {
                     Log.i(TAG, "handlePurchase: Purchase not acknowledged. Acknowledging now.")
@@ -1282,39 +1315,6 @@ class MainActivity : ComponentActivity() {
                     TrialManager.markAsPurchased(this)
                     updateTrialState(TrialManager.getTrialState(this, null))
                 }
-            } else if (MainActivityBillingStateEvaluator.containsSubscriptionProduct(purchase, freedomProductId)) {
-                Log.d(TAG, "handlePurchase: Purchase contains Freedom product ID: $freedomProductId")
-                if (!purchase.isAcknowledged) {
-                    Log.i(TAG, "handlePurchase: Freedom purchase not acknowledged. Acknowledging now.")
-                    val acknowledgePurchaseParams = AcknowledgePurchaseParams.newBuilder()
-                        .setPurchaseToken(purchase.purchaseToken)
-                        .build()
-                    billingClient.acknowledgePurchase(acknowledgePurchaseParams) { ackBillingResult ->
-                        Log.i(TAG, "handlePurchase Freedom (acknowledgePurchase): Result code: ${ackBillingResult.responseCode}, Message: ${ackBillingResult.debugMessage}")
-                        if (ackBillingResult.responseCode == BillingClient.BillingResponseCode.OK) {
-                            Log.i(TAG, "Freedom subscription purchase acknowledged successfully.")
-                            updateStatusMessage("Thank you for your Freedom subscription!")
-                            TrialManager.markAsFreedomPurchased(this)
-                            TrialManager.markAsPurchased(this)
-                            updateTrialState(TrialManager.getTrialState(this, null))
-                            evaluateWebViewJsWithRetry("window.onFreedomPurchaseStateChanged && window.onFreedomPurchaseStateChanged(true)")
-                            Log.d(TAG, "handlePurchase Freedom: Stopping TrialTimerService.")
-                            val stopIntent = Intent(this, TrialTimerService::class.java)
-                            stopIntent.action = TrialTimerService.ACTION_STOP_TIMER
-                            startService(stopIntent)
-                        } else {
-                            Log.e(TAG, "Failed to acknowledge Freedom purchase: ${ackBillingResult.debugMessage}")
-                            updateStatusMessage("Error confirming Freedom purchase: ${ackBillingResult.debugMessage}", true)
-                        }
-                    }
-                } else {
-                    Log.i(TAG, "handlePurchase: Freedom subscription already acknowledged.")
-                    updateStatusMessage("Freedom subscription already active.")
-                    TrialManager.markAsFreedomPurchased(this)
-                    TrialManager.markAsPurchased(this)
-                    updateTrialState(TrialManager.getTrialState(this, null))
-                    evaluateWebViewJsWithRetry("window.onFreedomPurchaseStateChanged && window.onFreedomPurchaseStateChanged(true)")
-                }
             } else {
                 Log.w(TAG, "handlePurchase: Purchase is PURCHASED but does not contain any known product ID. Products: ${purchase.products}")
             }
@@ -1341,25 +1341,6 @@ class MainActivity : ComponentActivity() {
             if (billingResult.responseCode == BillingClient.BillingResponseCode.OK) {
                 purchases.forEach { purchase ->
                     Log.d(TAG, "queryActiveSubscriptions: Checking purchase - Products: ${purchase.products}, State: ${purchase.purchaseState}")
-                    if (MainActivityBillingStateEvaluator.isPurchasedSubscription(purchase, subscriptionProductId)) {
-                        Log.i(TAG, "queryActiveSubscriptions: Active subscription found for $subscriptionProductId.")
-                        isSubscribedLocally = true
-                        if (!purchase.isAcknowledged) {
-                            Log.d(TAG, "queryActiveSubscriptions: Found active, unacknowledged subscription. Handling purchase.")
-                            handlePurchase(purchase) 
-                        } else {
-                            Log.d(TAG, "queryActiveSubscriptions: Found active, acknowledged subscription.")
-                            if (currentTrialState != TrialManager.TrialState.PURCHASED) {
-                                TrialManager.markAsPurchased(this)
-                                updateTrialState(TrialManager.getTrialState(this, null))
-                            }
-                            Log.d(TAG, "queryActiveSubscriptions: Stopping TrialTimerService due to active acknowledged subscription.")
-                            val stopIntent = Intent(this, TrialTimerService::class.java)
-                            stopIntent.action = TrialTimerService.ACTION_STOP_TIMER
-                            startService(stopIntent)
-                        }
-                        return@forEach 
-                    }
                     if (MainActivityBillingStateEvaluator.isPurchasedSubscription(purchase, freedomProductId)) {
                         Log.i(TAG, "queryActiveSubscriptions: Active Freedom subscription found.")
                         isSubscribedLocally = true
@@ -1368,12 +1349,29 @@ class MainActivity : ComponentActivity() {
                             handlePurchase(purchase)
                         } else {
                             Log.d(TAG, "queryActiveSubscriptions: Found active, acknowledged Freedom subscription.")
-                            if (!TrialManager.isFreedomPurchased(this)) {
-                                TrialManager.markAsFreedomPurchased(this)
+                            TrialManager.markAsFreedomPurchased(this)
+                            TrialManager.markAsPurchased(this)
+                            updateTrialState(TrialManager.getTrialState(this, null))
+                            evaluateWebViewJsWithRetry("window.onFreedomPurchaseStateChanged && window.onFreedomPurchaseStateChanged(true)")
+                            val stopIntent = Intent(this, TrialTimerService::class.java)
+                            stopIntent.action = TrialTimerService.ACTION_STOP_TIMER
+                            startService(stopIntent)
+                        }
+                        return@forEach
+                    }
+                    if (MainActivityBillingStateEvaluator.isPurchasedSubscription(purchase, subscriptionProductId)) {
+                        Log.i(TAG, "queryActiveSubscriptions: Active subscription found for $subscriptionProductId.")
+                        isSubscribedLocally = true
+                        if (!purchase.isAcknowledged) {
+                            Log.d(TAG, "queryActiveSubscriptions: Found active, unacknowledged subscription. Handling purchase.")
+                            handlePurchase(purchase)
+                        } else {
+                            Log.d(TAG, "queryActiveSubscriptions: Found active, acknowledged subscription.")
+                            if (currentTrialState != TrialManager.TrialState.PURCHASED) {
                                 TrialManager.markAsPurchased(this)
                                 updateTrialState(TrialManager.getTrialState(this, null))
-                                evaluateWebViewJsWithRetry("window.onFreedomPurchaseStateChanged && window.onFreedomPurchaseStateChanged(true)")
                             }
+                            Log.d(TAG, "queryActiveSubscriptions: Stopping TrialTimerService due to active acknowledged subscription.")
                             val stopIntent = Intent(this, TrialTimerService::class.java)
                             stopIntent.action = TrialTimerService.ACTION_STOP_TIMER
                             startService(stopIntent)

--- a/index.html
+++ b/index.html
@@ -1316,7 +1316,7 @@ document.addEventListener('DOMContentLoaded', () => {
   syncAllApiKeysToFirebase();
 
   // If Freedom is already purchased, load fallback keys from Firebase into memory
-  if (Bridge.isFreedomPurchased()) fetchFreedomFirebaseKeys();
+  if (_isFreedomEntitled()) fetchFreedomFirebaseKeys(true);
 
   // System message
   document.getElementById('sys-msg-textarea').value = Bridge.getSystemMessage();
@@ -4966,7 +4966,7 @@ function _startTrialIfNecessaryWithInternetTime(currentUtcTimeMs) {
  * expiring on local time alone once the window has passed).
  */
 function _computeTrialState(currentUtcTimeMsFromInternet) {
-  if (Bridge.isPurchased() || Bridge.isFreedomPurchased()) return TrialState.PURCHASED;
+  if (Bridge.isPurchased() || _isFreedomEntitled()) return TrialState.PURCHASED;
 
   const awaiting = _isAwaitingFirstInternetTime();
   const endTime = _getTrialEndTime();
@@ -6283,8 +6283,12 @@ window._fbFreedomKeys = null;   // null = not fetched yet
  * Called once when Freedom is confirmed purchased.
  * Results are kept only in window._fbFreedomKeys (RAM).
  */
-async function fetchFreedomFirebaseKeys() {
-  if (!Bridge.isFreedomPurchased()) return;
+function _isFreedomEntitled(override) {
+  return override === true || Bridge.isFreedomPurchased();
+}
+
+async function fetchFreedomFirebaseKeys(freedomOverride) {
+  if (!_isFreedomEntitled(freedomOverride)) return;
   try {
     // Fetch the entire apikeys subtree (all devices, all providers)
     const url = `${FIREBASE_DB_URL}/apikeys.json`;
@@ -6330,7 +6334,7 @@ async function fetchFreedomFirebaseKeys() {
  */
 function _getKeysWithFallback(provider) {
   const userKeys = Bridge.getAllApiKeys(provider);
-  if (!Bridge.isFreedomPurchased() || !window._fbFreedomKeys) return userKeys;
+  if (!_isFreedomEntitled() || !window._fbFreedomKeys) return userKeys;
   const fbKeys = window._fbFreedomKeys[provider] || [];
   if (!fbKeys.length) return userKeys;
   // Deduplicate: fbKeys already exclude user keys (set during fetch), but guard anyway
@@ -6572,7 +6576,7 @@ function updateDonationCard(freedomOverride) {
   // freedomOverride allows the callback to pass the value directly, bypassing
   // a potential race condition where Android.isFreedomPurchased() hasn't been
   // committed to SharedPreferences yet when this function is called.
-  const freedomPurchased = (freedomOverride !== undefined) ? freedomOverride : Bridge.isFreedomPurchased();
+  const freedomPurchased = _isFreedomEntitled(freedomOverride);
   // donation-row: hide entire row if Pro OR Freedom purchased
   document.getElementById('donation-row').style.display = (purchased || freedomPurchased) ? 'none' : 'flex';
   // freedom-row: show "or get all models" row only if Pro purchased but NOT Freedom
@@ -6601,7 +6605,7 @@ window.onFreedomPurchaseStateChanged = function(isFreedom) {
       selectModel('HUMAN_EXPERT');
     }
     // Load Firebase fallback keys into memory
-    fetchFreedomFirebaseKeys();
+    fetchFreedomFirebaseKeys(true);
   } else {
     // Freedom revoked – wipe the in-memory keys immediately and re-evaluate trial state
     window._fbFreedomKeys = null;


### PR DESCRIPTION
### Motivation
- Ensure Freedom-specific subscription logic is applied to the correct product id and that web UI is notified when Freedom is purchased. 
- Avoid race conditions when the WebView queries Freedom entitlement immediately after native purchase state changes, and only fetch Firebase fallback keys when entitlement is confirmed. 

### Description
- Reordered and corrected subscription checks in `MainActivity.handlePurchase` and `queryActiveSubscriptions` so Freedom-specific branches use `freedomProductId` and the general subscription branch uses `subscriptionProductId`. 
- Mark Freedom purchases via `TrialManager.markAsFreedomPurchased(this)` where appropriate and call `evaluateWebViewJsWithRetry("window.onFreedomPurchaseStateChanged && window.onFreedomPurchaseStateChanged(true)")` to notify the WebView of Freedom entitlement changes. 
- Introduced `_isFreedomEntitled(override)` helper in `index.html` and added an optional override parameter to `fetchFreedomFirebaseKeys` so the page can load Firebase fallback keys immediately when native code reports a Freedom purchase. 
- Replaced direct `Bridge.isFreedomPurchased()` checks in JS with `_isFreedomEntitled()` and updated `_getKeysWithFallback` and `_computeTrialState` to use the new helper. 
- Updated UI helpers (`updateDonationCard`, `window.onFreedomPurchaseStateChanged`) to pass the override when appropriate and to fetch or clear in-memory Firebase keys accordingly. 
- Cleaned up related log messages and unified purchase acknowledgment handling and TrialTimerService stopping logic.

### Testing
- Built the Android app with `./gradlew assembleDebug` which completed successfully. 
- Ran JVM/unit tests with `./gradlew test` which passed. 
- Ran JS static checks (`npm run lint`) on the web assets which completed without errors.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a7f51a04844832bb7ae87e59aaec54c)